### PR TITLE
Fix unclickable admin menu by adding missing class to modal div

### DIFF
--- a/administrator/components/com_banners/views/banners/tmpl/default_batch.php
+++ b/administrator/components/com_banners/views/banners/tmpl/default_batch.php
@@ -11,7 +11,7 @@ defined('_JEXEC') or die;
 
 $published = $this->state->get('filter.published');
 ?>
-<div class="modal fade" id="collapseModal">
+<div class="modal hide fade" id="collapseModal">
 	<div class="modal-header">
 		<button type="button" class="close" data-dismiss="modal">x</button>
 		<h3><?php echo JText::_('COM_BANNERS_BATCH_OPTIONS');?></h3>

--- a/administrator/components/com_categories/views/categories/tmpl/default_batch.php
+++ b/administrator/components/com_categories/views/categories/tmpl/default_batch.php
@@ -16,7 +16,7 @@ $options = array(
 $published	= $this->state->get('filter.published');
 $extension	= $this->escape($this->state->get('filter.extension'));
 ?>
-<div class="modal fade" id="collapseModal">
+<div class="modal hide fade" id="collapseModal">
 	<div class="modal-header">
 		<button type="button" class="close" data-dismiss="modal">x</button>
 		<h3><?php echo JText::_('COM_CATEGORIES_BATCH_OPTIONS');?></h3>

--- a/administrator/components/com_contact/views/contacts/tmpl/default_batch.php
+++ b/administrator/components/com_contact/views/contacts/tmpl/default_batch.php
@@ -11,7 +11,7 @@ defined('_JEXEC') or die;
 
 $published = $this->state->get('filter.published');
 ?>
-<div class="modal fade" id="collapseModal">
+<div class="modal hide fade" id="collapseModal">
 	<div class="modal-header">
 		<button type="button" class="close" data-dismiss="modal">x</button>
 		<h3><?php echo JText::_('COM_CONTACT_BATCH_OPTIONS');?></h3>

--- a/administrator/components/com_content/views/articles/tmpl/default_batch.php
+++ b/administrator/components/com_content/views/articles/tmpl/default_batch.php
@@ -11,9 +11,9 @@ defined('_JEXEC') or die;
 
 $published = $this->state->get('filter.published');
 ?>
-<div class="modal fade" id="collapseModal">
+<div class="modal hide fade" id="collapseModal">
 	<div class="modal-header">
-		<button type="button" class="close" data-dismiss="modal">x</button>
+		<button type="button" role="presentation" class="close" data-dismiss="modal">x</button>
 		<h3><?php echo JText::_('COM_CONTENT_BATCH_OPTIONS');?></h3>
 	</div>
 	<div class="modal-body">

--- a/administrator/components/com_menus/views/items/tmpl/default_batch.php
+++ b/administrator/components/com_menus/views/items/tmpl/default_batch.php
@@ -15,7 +15,7 @@ $options = array(
 );
 $published = $this->state->get('filter.published');
 ?>
-<div class="modal fade" id="collapseModal">
+<div class="modal hide fade" id="collapseModal">
 	<div class="modal-header">
 		<button type="button" class="close" data-dismiss="modal">x</button>
 		<h3><?php echo JText::_('COM_MENUS_BATCH_OPTIONS');?></h3>

--- a/administrator/components/com_modules/views/modules/tmpl/default_batch.php
+++ b/administrator/components/com_modules/views/modules/tmpl/default_batch.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 $clientId = $this->state->get('filter.client_id');
 $published = $this->state->get('filter.published');
 ?>
-<div class="modal fade" id="collapseModal">
+<div class="modal hide fade" id="collapseModal">
 	<div class="modal-header">
 		<button type="button" class="close" data-dismiss="modal">x</button>
 		<h3><?php echo JText::_('COM_MODULES_BATCH_OPTIONS');?></h3>

--- a/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/default_batch.php
+++ b/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/default_batch.php
@@ -11,7 +11,7 @@ defined('_JEXEC') or die;
 
 $published = $this->state->get('filter.published');
 ?>
-<div class="modal fade" id="collapseModal">
+<div class="modal hide fade" id="collapseModal">
 	<div class="modal-header">
 		<button type="button" class="close" data-dismiss="modal">x</button>
 		<h3><?php echo JText::_('COM_NEWSFEEDS_BATCH_OPTIONS');?></h3>


### PR DESCRIPTION
The collapseModal div in the default_batch templates need to have the class hide in addition to modal fade to disappear completely. Otherwise it invisibly overlays most of the menu causing it to be unclickable
