### PR TITLE
Fix install DB creation

### DIFF
--- a/installation/models/database.php
+++ b/installation/models/database.php
@@ -136,7 +136,12 @@ class InstallationModelDatabase extends JModelLegacy
 	public function createDatabase($options)
 	{
 		// Disable autoselect database before it's created
-		$options['db_select'] = 0;
+		$tmpSelect = true;
+		if (isset($options['db_select']))
+		{
+			$tmpSelect = $options['db_select'];
+		}
+		$options['db_select'] = false;
 
 		if (!$db = $this->initialise($options))
 		{
@@ -217,8 +222,8 @@ class InstallationModelDatabase extends JModelLegacy
 		}
 		$options = array_merge(array('db_created'=>1), $options);
 
-		// Enable autoselect database after database creation
-		$options['db_select'] = 1;
+		// Restore autoselect value after database creation
+		$options['db_select'] = $tmpSelect;
 
 		$session = JFactory::getSession();
 		$session->set('setup.options', $options);

--- a/installation/models/database.php
+++ b/installation/models/database.php
@@ -121,7 +121,7 @@ class InstallationModelDatabase extends JModelLegacy
 		// Get a database object.
 		try
 		{
-			return InstallationHelperDatabase::getDbo($options->db_type, $options->db_host, $options->db_user, $options->db_pass, $options->db_name, $options->db_prefix);
+			return InstallationHelperDatabase::getDbo($options->db_type, $options->db_host, $options->db_user, $options->db_pass, $options->db_name, $options->db_prefix, $options->db_select);
 		}
 		catch (RuntimeException $e)
 		{
@@ -135,6 +135,9 @@ class InstallationModelDatabase extends JModelLegacy
 	 */
 	public function createDatabase($options)
 	{
+		// Disable autoselect database before it's created
+		$options['db_select'] = 0;
+
 		if (!$db = $this->initialise($options))
 		{
 			return false;
@@ -213,6 +216,10 @@ class InstallationModelDatabase extends JModelLegacy
 			}
 		}
 		$options = array_merge(array('db_created'=>1), $options);
+
+		// Enable autoselect database after database creation
+		$options['db_select'] = 1;
+
 		$session = JFactory::getSession();
 		$session->set('setup.options', $options);
 


### PR DESCRIPTION
DB creation was broken during installation because it was trying to autoconnect to the non-existent database before it's created.

Issue reported in: 
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=28899
