### PR TITLE
Fix undefined ftp_enable with display_errors = On and email on

### DIFF
--- a/installation/controllers/setup.json.php
+++ b/installation/controllers/setup.json.php
@@ -351,7 +351,7 @@ class InstallationControllerSetup extends JControllerLegacy
 		$body[] = array(JText::_('INSTL_DATABASE_NAME_LABEL'), $options['db_name']);
 		$body[] = array(JText::_('INSTL_DATABASE_PREFIX_LABEL'), $options['db_prefix']);
 
-		if ($options['ftp_enable']) {
+		if (isset($options['ftp_enable']) && $options['ftp_enable']) {
 			$body[] = $this->emailTitle(JText::_('INSTL_FTP'));
 			$body[] = array(JText::_('INSTL_FTP_USER_LABEL'), $options['ftp_user']);
 			if ($options['summary_email_passwords']) {


### PR DESCRIPTION
Without FTP options now we have a missing key ftp_enable.

Reproduce:
1- Setup php.ini with display_errors = on
2- In the installation step2 set email configuration to yes

The setup.json.php response is broken by the message:

Notice: Undefined index: ftp_enable in /installation/controllers/setup.json.php on line 354
