### PR TITLE
Forces IE to use the latest rendering engine

### DIFF
--- a/administrator/templates/isis/login.php
+++ b/administrator/templates/isis/login.php
@@ -34,6 +34,7 @@ $sitename = $app->getCfg('sitename');
 <html>
 <head>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
 	<script src="../media/jui/js/jquery.js"></script>
 	<script src="../media/jui/js/bootstrap.min.js"></script>
 	<script src="../media/jui/js/chosen.jquery.min.js"></script>


### PR DESCRIPTION
If IE 8/9 is in compatibilty mode it isn't possible to login to
/administrator. This meta forces IE to uses the latest available
rendering engine, switching it out of compatibility mode even if the
user already has it enabled, allowing them to login.
