### PR TITLE
Fix refreshManifestCache

### DIFF
--- a/administrator/components/com_modules/models/select.php
+++ b/administrator/components/com_modules/models/select.php
@@ -118,14 +118,14 @@ class ModulesModelSelect extends JModelList
 		// Loop through the results to add the XML metadata,
 		// and load language support.
 		foreach ($items as &$item) {
-			$path = JPath::clean($client->path.'/modules/'.$item->module.'/'.$item->module.'.xml');
-			if (file_exists($path)) {
-				$item->xml = simplexml_load_file($path);
-			} else {
-				$item->xml = null;
-			}
+			// Get the manifest file from installer
+			$installer = JInstaller::getInstance();
+			$manifestPath = $client->path . '/modules/' . $item->module;
+			$installer->setPath('source', $manifestPath);
+			$installer->manifest = null; // Reset manifest instance cache
+			$item->xml = $installer->getManifest();
 
-					// 1.5 Format; Core files or language packs then
+			// 1.5 Format; Core files or language packs then
 			// 1.6 3PD Extension Support
 				$lang->load($item->module.'.sys', $client->path, null, false, false)
 			||	$lang->load($item->module.'.sys', $client->path.'/modules/'.$item->module, null, false, false)

--- a/administrator/includes/toolbar.php
+++ b/administrator/includes/toolbar.php
@@ -566,7 +566,7 @@ abstract class JToolbarHelper
 	 *
 	 * @since   1.5
 	 */
-	public static function preferences($component, $height = '550', $width = '875' $alt = 'JToolbar_Options', $path = '')
+	public static function preferences($component, $height = '550', $width = '875', $alt = 'JToolbar_Options', $path = '')
 	{
 		$component = urlencode($component);
 		$path = urlencode($path);

--- a/libraries/joomla/installer/adapters/component.php
+++ b/libraries/joomla/installer/adapters/component.php
@@ -1791,9 +1791,9 @@ class JInstallerComponent extends JAdapterInstance
 		// Need to find to find where the XML file is since we don't store this normally
 		$client = JApplicationHelper::getClientInfo($this->parent->extension->client_id);
 		$short_element = str_replace('com_', '', $this->parent->extension->element);
-		$manifestPath = $client->path . '/components/' . $this->parent->extension->element . '/' . $short_element . '.xml';
-		$this->parent->manifest = $this->parent->isManifest($manifestPath);
-		$this->parent->setPath('manifest', $manifestPath);
+		$manifestPath = $client->path . '/components/' . $this->parent->extension->element;
+		$this->parent->setPath('source', $manifestPath);
+		$this->parent->manifest = $this->parent->getManifest();
 
 		$manifest_details = JInstaller::parseXMLInstallFile($this->parent->getPath('manifest'));
 		$this->parent->extension->manifest_cache = json_encode($manifest_details);

--- a/libraries/joomla/installer/adapters/module.php
+++ b/libraries/joomla/installer/adapters/module.php
@@ -686,9 +686,10 @@ class JInstallerModule extends JAdapterInstance
 	public function refreshManifestCache()
 	{
 		$client = JApplicationHelper::getClientInfo($this->parent->extension->client_id);
-		$manifestPath = $client->path . '/modules/' . $this->parent->extension->element . '/' . $this->parent->extension->element . '.xml';
-		$this->parent->manifest = $this->parent->isManifest($manifestPath);
-		$this->parent->setPath('manifest', $manifestPath);
+		$manifestPath = $client->path . '/modules/' . $this->parent->extension->element;
+		$this->parent->setPath('source', $manifestPath);
+		$this->parent->manifest = $this->parent->getManifest();
+
 		$manifest_details = JInstaller::parseXMLInstallFile($this->parent->getPath('manifest'));
 		$this->parent->extension->manifest_cache = json_encode($manifest_details);
 		$this->parent->extension->name = $manifest_details['name'];

--- a/libraries/joomla/installer/adapters/plugin.php
+++ b/libraries/joomla/installer/adapters/plugin.php
@@ -834,10 +834,10 @@ class JInstallerPlugin extends JAdapterInstance
 		 * If it's not in the extensions table we just add it
 		 */
 		$client = JApplicationHelper::getClientInfo($this->parent->extension->client_id);
-		$manifestPath = $client->path . '/plugins/' . $this->parent->extension->folder . '/' . $this->parent->extension->element . '/'
-			. $this->parent->extension->element . '.xml';
-		$this->parent->manifest = $this->parent->isManifest($manifestPath);
-		$this->parent->setPath('manifest', $manifestPath);
+		$manifestPath = $client->path . '/plugins/' . $this->parent->extension->folder . '/' . $this->parent->extension->element;
+		$this->parent->setPath('source', $manifestPath);
+		$this->parent->manifest = $this->parent->getManifest();
+
 		$manifest_details = JInstaller::parseXMLInstallFile($this->parent->getPath('manifest'));
 		$this->parent->extension->manifest_cache = json_encode($manifest_details);
 

--- a/libraries/joomla/installer/adapters/template.php
+++ b/libraries/joomla/installer/adapters/template.php
@@ -608,9 +608,9 @@ class JInstallerTemplate extends JAdapterInstance
 	{
 		// Need to find to find where the XML file is since we don't store this normally.
 		$client = JApplicationHelper::getClientInfo($this->parent->extension->client_id);
-		$manifestPath = $client->path . '/templates/' . $this->parent->extension->element . '/templateDetails.xml';
-		$this->parent->manifest = $this->parent->isManifest($manifestPath);
-		$this->parent->setPath('manifest', $manifestPath);
+		$manifestPath = $client->path . '/templates/' . $this->parent->extension->element;
+		$this->parent->setPath('source', $manifestPath);
+		$this->parent->manifest = $this->parent->getManifest();
 
 		$manifest_details = JInstaller::parseXMLInstallFile($this->parent->getPath('manifest'));
 		$this->parent->extension->manifest_cache = json_encode($manifest_details);


### PR DESCRIPTION
The com_installer use the first valid XML file to install a extension but refreshManifestCache looks for a fixed name, so if the developer changed the XML name it will install but not refresh the manifest cache.

So, if the extension has a manifest.xml as the manifest file it can install, but not refresh the manifest cache later, since the current adapters look for a com_compname.xml, mod_modname.xml... now it will look for the first valid XML.

I fixed to make consistent with the installation behavior.
